### PR TITLE
Git ignore PyPDF2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.pyc
 *.swp
+PyPDF2


### PR DESCRIPTION
Ignore PyPDF2.
Ovo nam treba kad rucno instaliramo package.
